### PR TITLE
remove slashes from escaped characters in options names

### DIFF
--- a/includes/class.xprofile.php
+++ b/includes/class.xprofile.php
@@ -178,8 +178,8 @@ class BPML_XProfile
 
     protected function _t_option_name( $option, $field_id ) {
         if ( !empty( $option->name ) ) {
-            return apply_filters( 'wpml_translate_single_string', $option->name, $this->_context,
-                    $this->sanitize_option_basename( $option, $field_id ) . ' name' );
+            return wp_unslash(apply_filters( 'wpml_translate_single_string', $option->name, $this->_context,
+                    $this->sanitize_option_basename( $option, $field_id ) . ' name' ));
         }
         return isset( $option->name ) ? $option->name : '';
     }


### PR DESCRIPTION
Temporary workaround to remove slashes from Buddypress Formular used with buddypress-multilingual and WPML.

Same as here :  https://github.com/telabotanica/buddypress-multilingual/pull/1

Caution : update the buddypress-multilingual plugin will break this.

See here : Taiga #773 , and here :  https://wpml.org/forums/topic/buddypress-multilingual-escaping-fields-names/

Related to https://github.com/OnTheGoSystems/buddypress-multilingual/issues/11
![some_options_with_slashes](https://user-images.githubusercontent.com/29776142/29276882-4d6cc682-8110-11e7-9bf0-1ef4af1267de.png)


